### PR TITLE
Binding to datalist custom params

### DIFF
--- a/src/views.js
+++ b/src/views.js
@@ -182,6 +182,9 @@ export class Views {
 				}
 			}
 			view.className = classes.join(' ');
+		} else if (targetProperty.includes('data-')) {
+			const datasetName = targetProperty.split('-')[1];
+			view.dataset[datasetName] = value;
 		} else {
 			view[targetProperty] = value;
 		}


### PR DESCRIPTION
Binding to custom params of datalist, all with 'data-' prefix, ie. 'data-something' as attribute of DOM element:
`<div data-tie="tieKeyA:status => data-something">`

and the DOM will be updates as: 
`<div data-something="some status value" data-tie="tieKeyA:status => data-something">`

Unfortunately, without the patch it updates the DOM with no changes by the line:
`			view[targetProperty] = value;`

so, the mine "else if" from the pull requests before saves the day.